### PR TITLE
Added personal direct friend invite link endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,9 +147,10 @@
     getDMs: () => apiCall(`/users/@me/channels`),
     getUser: userId => apiCall(`/users/${userId}`),
 
-    getFriendInvite: () => apiCall(`/users/@me/invites`),
+    getFriendInvites: () => apiCall(`/users/@me/invites`),
     createFriendInvite: () => apiCall(`/users/@me/invites`, null, 'POST'),
-    deleteFriendInvite: () => apiCall(`/users/@me/invites`, null, 'DELETE'),
+    deleteFriendInvites: () => apiCall(`/users/@me/invites`, null, 'DELETE'),
+	  deleteFriendInvite: (code) => apiCall(`/users/@me/invites`, code, 'DELETE'),
 
     getCurrentUser: () => apiCall('/users/@me'),
     editCurrentUser: (username, bio, body = {}) => apiCall('/users/@me', { username: username ?? undefined, bio: bio ?? undefined, ...body }, 'PATCH'),

--- a/index.js
+++ b/index.js
@@ -147,6 +147,10 @@
     getDMs: () => apiCall(`/users/@me/channels`),
     getUser: userId => apiCall(`/users/${userId}`),
 
+    getFriendInvite: () => apiCall(`/users/@me/invites`),
+    createFriendInvite: () => apiCall(`/users/@me/invites`, null, 'POST'),
+    deleteFriendInvite: () => apiCall(`/users/@me/invites`, null, 'DELETE'),
+
     getCurrentUser: () => apiCall('/users/@me'),
     editCurrentUser: (username, bio, body = {}) => apiCall('/users/@me', { username: username ?? undefined, bio: bio ?? undefined, ...body }, 'PATCH'),
 

--- a/index.js
+++ b/index.js
@@ -150,7 +150,6 @@
     getFriendInvites: () => apiCall(`/users/@me/invites`),
     createFriendInvite: () => apiCall(`/users/@me/invites`, null, 'POST'),
     deleteFriendInvites: () => apiCall(`/users/@me/invites`, null, 'DELETE'),
-	  deleteFriendInvite: (code) => apiCall(`/users/@me/invites`, code, 'DELETE'),
 
     getCurrentUser: () => apiCall('/users/@me'),
     editCurrentUser: (username, bio, body = {}) => apiCall('/users/@me', { username: username ?? undefined, bio: bio ?? undefined, ...body }, 'PATCH'),

--- a/index.js
+++ b/index.js
@@ -147,9 +147,9 @@
     getDMs: () => apiCall(`/users/@me/channels`),
     getUser: userId => apiCall(`/users/${userId}`),
 
-    getFriendInvites: () => apiCall(`/users/@me/invites`),
-    createFriendInvite: () => apiCall(`/users/@me/invites`, null, 'POST'),
-    deleteFriendInvites: () => apiCall(`/users/@me/invites`, null, 'DELETE'),
+    getDirectFriendInviteLinks: () => apiCall(`/users/@me/invites`),
+    createDirectFriendInviteLink: () => apiCall(`/users/@me/invites`, null, 'POST'),
+    deleteDirectFriendInviteLinks: () => apiCall(`/users/@me/invites`, null, 'DELETE'),
 
     getCurrentUser: () => apiCall('/users/@me'),
     editCurrentUser: (username, bio, body = {}) => apiCall('/users/@me', { username: username ?? undefined, bio: bio ?? undefined, ...body }, 'PATCH'),

--- a/types.d.ts
+++ b/types.d.ts
@@ -147,9 +147,10 @@ export type api = {
   getDMs(): Promise<any>
   getUser(userId: string): Promise<User>
 
-  getFriendInvite(): Promise<any>
+  getFriendInvites(): Promise<any>
   createFriendInvite(): Promise<any>
-  deleteFriendInvite(): Promise<any>
+  deleteFriendInvites(): Promise<any>
+  deleteFriendInvite(code: string): Promise<any>
 
   getCurrentUser(): Promise<User>
   editCurrentUser(username?: string, bio?: string, body?: any): Promise<User>

--- a/types.d.ts
+++ b/types.d.ts
@@ -147,9 +147,9 @@ export type api = {
   getDMs(): Promise<any>
   getUser(userId: string): Promise<User>
 
-  getFriendInvites(): Promise<any>
-  createFriendInvite(): Promise<any>
-  deleteFriendInvites(): Promise<any>
+  getDirectFriendInviteLinks(): Promise<any>
+  createDirectFriendInviteLink(): Promise<any>
+  deleteDirectFriendInviteLinks(): Promise<any>
 
   getCurrentUser(): Promise<User>
   editCurrentUser(username?: string, bio?: string, body?: any): Promise<User>

--- a/types.d.ts
+++ b/types.d.ts
@@ -147,6 +147,10 @@ export type api = {
   getDMs(): Promise<any>
   getUser(userId: string): Promise<User>
 
+  getFriendInvite(): Promise<any>
+  createFriendInvite(): Promise<any>
+  deleteFriendInvite(): Promise<any>
+
   getCurrentUser(): Promise<User>
   editCurrentUser(username?: string, bio?: string, body?: any): Promise<User>
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -150,7 +150,6 @@ export type api = {
   getFriendInvites(): Promise<any>
   createFriendInvite(): Promise<any>
   deleteFriendInvites(): Promise<any>
-  deleteFriendInvite(code: string): Promise<any>
 
   getCurrentUser(): Promise<User>
   editCurrentUser(username?: string, bio?: string, body?: any): Promise<User>


### PR DESCRIPTION
Updated;

+ getFriendInvites()
+ createFriendInvite()
+ deleteFriendInvites()

getFriendInvites is returning your active Friend Invites.
createFriendInvite is giving Friend Invite for use 5 times. 
deleteFriendInvites is deleting your all Friend Invite.

You can use the "code". (Length 8 char.)
E.g: https://discord.gg/AaBbcCDd

I hope you guys understand what I said here.